### PR TITLE
Implement a POC for spl_object_id(object $x) : int

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -28,9 +28,11 @@ PHP                                                                        NEWS
     (Anatol)
 
 - SPL:
+  . Added spl_object_id() function returning an integer (the object handle) for an object.
+    (Tyson Andre)
   . Fixed bug #73471 (PHP freezes with AppendIterator). (jhdxr)
   . Fixed bug #71412 (Incorrect arginfo for ArrayIterator::__construct).
-    (tysonandre775 at hotmail dot com)
+    (Tyson Andre)
 
 - Session:
   . Fixed bug #74514 (5 session functions incorrectly warn when calling in

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -804,42 +804,24 @@ PHP_FUNCTION(spl_object_id)
 		Z_PARAM_OBJECT(obj)
 	ZEND_PARSE_PARAMETERS_END_EX(RETURN_NULL());
 
-	RETURN_LONG(php_spl_object_id(obj));
+	RETURN_LONG((zend_long)Z_OBJ_HANDLE_P(obj));
 }
 /* }}} */
-
-static void php_spl_init_hash_mask() {
-	SPL_G(hash_mask_handle)   = (intptr_t)(php_mt_rand() >> 1);
-	SPL_G(hash_mask_handlers) = (intptr_t)(php_mt_rand() >> 1);
-	SPL_G(hash_mask_init) = 1;
-}
 
 PHPAPI zend_string *php_spl_object_hash(zval *obj) /* {{{*/
 {
 	intptr_t hash_handle, hash_handlers;
 
 	if (!SPL_G(hash_mask_init)) {
-		php_spl_init_hash_mask();
+		SPL_G(hash_mask_handle)   = (intptr_t)(php_mt_rand() >> 1);
+		SPL_G(hash_mask_handlers) = (intptr_t)(php_mt_rand() >> 1);
+		SPL_G(hash_mask_init) = 1;
 	}
 
 	hash_handle   = SPL_G(hash_mask_handle)^(intptr_t)Z_OBJ_HANDLE_P(obj);
 	hash_handlers = SPL_G(hash_mask_handlers);
 
 	return strpprintf(32, "%016zx%016zx", hash_handle, hash_handlers);
-}
-/* }}} */
-
-PHPAPI zend_long php_spl_object_id(zval *obj) /* {{{*/
-{
-	intptr_t hash_handle;
-
-	if (!SPL_G(hash_mask_init)) {
-		php_spl_init_hash_mask();
-	}
-
-	hash_handle   = SPL_G(hash_mask_handle)^(intptr_t)Z_OBJ_HANDLE_P(obj);
-
-	return (zend_long) hash_handle;
 }
 /* }}} */
 

--- a/ext/spl/php_spl.c
+++ b/ext/spl/php_spl.c
@@ -794,20 +794,52 @@ PHP_FUNCTION(spl_object_hash)
 }
 /* }}} */
 
+/* {{{ proto int spl_object_id(object obj)
+ Return integer hash id for given object */
+PHP_FUNCTION(spl_object_id)
+{
+	zval *obj;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_OBJECT(obj)
+	ZEND_PARSE_PARAMETERS_END_EX(RETURN_NULL());
+
+	RETURN_LONG(php_spl_object_id(obj));
+}
+/* }}} */
+
+static void php_spl_init_hash_mask() {
+	SPL_G(hash_mask_handle)   = (intptr_t)(php_mt_rand() >> 1);
+	SPL_G(hash_mask_handlers) = (intptr_t)(php_mt_rand() >> 1);
+	SPL_G(hash_mask_init) = 1;
+}
+
 PHPAPI zend_string *php_spl_object_hash(zval *obj) /* {{{*/
 {
 	intptr_t hash_handle, hash_handlers;
 
 	if (!SPL_G(hash_mask_init)) {
-		SPL_G(hash_mask_handle)   = (intptr_t)(php_mt_rand() >> 1);
-		SPL_G(hash_mask_handlers) = (intptr_t)(php_mt_rand() >> 1);
-		SPL_G(hash_mask_init) = 1;
+		php_spl_init_hash_mask();
 	}
 
 	hash_handle   = SPL_G(hash_mask_handle)^(intptr_t)Z_OBJ_HANDLE_P(obj);
 	hash_handlers = SPL_G(hash_mask_handlers);
 
 	return strpprintf(32, "%016zx%016zx", hash_handle, hash_handlers);
+}
+/* }}} */
+
+PHPAPI zend_long php_spl_object_id(zval *obj) /* {{{*/
+{
+	intptr_t hash_handle;
+
+	if (!SPL_G(hash_mask_init)) {
+		php_spl_init_hash_mask();
+	}
+
+	hash_handle   = SPL_G(hash_mask_handle)^(intptr_t)Z_OBJ_HANDLE_P(obj);
+
+	return (zend_long) hash_handle;
 }
 /* }}} */
 
@@ -915,6 +947,10 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_hash, 0, 0, 1)
 	ZEND_ARG_INFO(0, obj)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_spl_object_id, 0, 0, 1)
+	ZEND_ARG_INFO(0, obj)
+ZEND_END_ARG_INFO()
 /* }}} */
 
 /* {{{ spl_functions
@@ -931,6 +967,7 @@ const zend_function_entry spl_functions[] = {
 	PHP_FE(class_implements,        arginfo_class_implements)
 	PHP_FE(class_uses,              arginfo_class_uses)
 	PHP_FE(spl_object_hash,         arginfo_spl_object_hash)
+	PHP_FE(spl_object_id,           arginfo_spl_object_id)
 #ifdef SPL_ITERATORS_H
 	PHP_FE(iterator_to_array,       arginfo_iterator_to_array)
 	PHP_FE(iterator_count,          arginfo_iterator)

--- a/ext/spl/php_spl.h
+++ b/ext/spl/php_spl.h
@@ -71,6 +71,7 @@ PHP_FUNCTION(class_implements);
 PHP_FUNCTION(class_uses);
 
 PHPAPI zend_string *php_spl_object_hash(zval *obj);
+PHPAPI zend_long php_spl_object_id(zval *obj);
 
 #endif /* PHP_SPL_H */
 

--- a/ext/spl/php_spl.h
+++ b/ext/spl/php_spl.h
@@ -71,7 +71,6 @@ PHP_FUNCTION(class_implements);
 PHP_FUNCTION(class_uses);
 
 PHPAPI zend_string *php_spl_object_hash(zval *obj);
-PHPAPI zend_long php_spl_object_id(zval *obj);
 
 #endif /* PHP_SPL_H */
 

--- a/ext/spl/tests/spl_object_id.phpt
+++ b/ext/spl/tests/spl_object_id.phpt
@@ -1,0 +1,24 @@
+--TEST--
+SPL: spl_object_id()
+--FILE--
+<?php
+
+var_dump(spl_object_id(new stdClass));
+var_dump(spl_object_id(42));
+var_dump(spl_object_id());
+$a = new stdClass();
+var_dump(spl_object_id(new stdClass) === spl_object_id($a));
+
+?>
+===DONE===
+<?php exit(0); ?>
+--EXPECTF--
+int(%d)
+
+Warning: spl_object_id() expects parameter 1 to be object, integer given in %sspl_object_id.php on line %d
+NULL
+
+Warning: spl_object_id() expects exactly 1 parameter, 0 given in %sspl_object_id.php on line %d
+NULL
+bool(false)
+===DONE===


### PR DESCRIPTION
https://github.com/runkit7/runkit_object_id is a C module which
implements the same functionality (Without obfuscation)

Pending question: Can `sizeof(zend_long)` be > `sizeof(intptr_t)`

- If so, detect that condition at compile time and return a binary string
  with that many bytes, instead.

Also, can two PHP "object"s have the same object id,
but different object handlers? (E.g. iterator of a class)

- If that is so, then document if this case is possible, but keep behaving the same way.