### PR TITLE
[draft] Fix arginfo for tidy's global functions and methods

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -98,6 +98,8 @@ PHP                                                                        NEWS
 
 - Tidy:
   . Added TIDY_TAG_* constants for HTML5 elements. (cmb)
+  . Fixed bug #76736 (wrong reflection for tidy_get_head, tidy_get_html,
+    tidy_get_root, and tidy_getopt) (tandre)
 
 - WDDX:
   . Deprecated the WDDX extension. (cmb)

--- a/Zend/zend_API.c
+++ b/Zend/zend_API.c
@@ -2038,31 +2038,31 @@ ZEND_API void zend_check_magic_method_implementation(const zend_class_entry *ce,
 	} else if (name_len == sizeof(ZEND_GET_FUNC_NAME) - 1 && !memcmp(lcname, ZEND_GET_FUNC_NAME, sizeof(ZEND_GET_FUNC_NAME) - 1)) {
 		if (fptr->common.num_args != 1) {
 			zend_error(error_type, "Method %s::%s() must take exactly 1 argument", ZSTR_VAL(ce->name), ZEND_GET_FUNC_NAME);
-		} else if (ARG_SHOULD_BE_SENT_BY_REF(fptr, 1)) {
+		} else if (QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 1)) {
 			zend_error(error_type, "Method %s::%s() cannot take arguments by reference", ZSTR_VAL(ce->name), ZEND_GET_FUNC_NAME);
 		}
 	} else if (name_len == sizeof(ZEND_SET_FUNC_NAME) - 1 && !memcmp(lcname, ZEND_SET_FUNC_NAME, sizeof(ZEND_SET_FUNC_NAME) - 1)) {
 		if (fptr->common.num_args != 2) {
 			zend_error(error_type, "Method %s::%s() must take exactly 2 arguments", ZSTR_VAL(ce->name), ZEND_SET_FUNC_NAME);
-		} else if (ARG_SHOULD_BE_SENT_BY_REF(fptr, 1) || ARG_SHOULD_BE_SENT_BY_REF(fptr, 2)) {
+		} else if (QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 1) || QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 2)) {
 			zend_error(error_type, "Method %s::%s() cannot take arguments by reference", ZSTR_VAL(ce->name), ZEND_SET_FUNC_NAME);
 		}
 	} else if (name_len == sizeof(ZEND_UNSET_FUNC_NAME) - 1 && !memcmp(lcname, ZEND_UNSET_FUNC_NAME, sizeof(ZEND_UNSET_FUNC_NAME) - 1)) {
 		if (fptr->common.num_args != 1) {
 			zend_error(error_type, "Method %s::%s() must take exactly 1 argument", ZSTR_VAL(ce->name), ZEND_UNSET_FUNC_NAME);
-		} else if (ARG_SHOULD_BE_SENT_BY_REF(fptr, 1)) {
+		} else if (QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 1)) {
 			zend_error(error_type, "Method %s::%s() cannot take arguments by reference", ZSTR_VAL(ce->name), ZEND_UNSET_FUNC_NAME);
 		}
 	} else if (name_len == sizeof(ZEND_ISSET_FUNC_NAME) - 1 && !memcmp(lcname, ZEND_ISSET_FUNC_NAME, sizeof(ZEND_ISSET_FUNC_NAME) - 1)) {
 		if (fptr->common.num_args != 1) {
 			zend_error(error_type, "Method %s::%s() must take exactly 1 argument", ZSTR_VAL(ce->name), ZEND_ISSET_FUNC_NAME);
-		} else if (ARG_SHOULD_BE_SENT_BY_REF(fptr, 1)) {
+		} else if (QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 1)) {
 			zend_error(error_type, "Method %s::%s() cannot take arguments by reference", ZSTR_VAL(ce->name), ZEND_ISSET_FUNC_NAME);
 		}
 	} else if (name_len == sizeof(ZEND_CALL_FUNC_NAME) - 1 && !memcmp(lcname, ZEND_CALL_FUNC_NAME, sizeof(ZEND_CALL_FUNC_NAME) - 1)) {
 		if (fptr->common.num_args != 2) {
 			zend_error(error_type, "Method %s::%s() must take exactly 2 arguments", ZSTR_VAL(ce->name), ZEND_CALL_FUNC_NAME);
-		} else if (ARG_SHOULD_BE_SENT_BY_REF(fptr, 1) || ARG_SHOULD_BE_SENT_BY_REF(fptr, 2)) {
+		} else if (QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 1) || QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 2)) {
 			zend_error(error_type, "Method %s::%s() cannot take arguments by reference", ZSTR_VAL(ce->name), ZEND_CALL_FUNC_NAME);
 		}
 	} else if (name_len == sizeof(ZEND_CALLSTATIC_FUNC_NAME) - 1 &&
@@ -2070,7 +2070,7 @@ ZEND_API void zend_check_magic_method_implementation(const zend_class_entry *ce,
 	) {
 		if (fptr->common.num_args != 2) {
 			zend_error(error_type, "Method %s::__callStatic() must take exactly 2 arguments", ZSTR_VAL(ce->name));
-		} else if (ARG_SHOULD_BE_SENT_BY_REF(fptr, 1) || ARG_SHOULD_BE_SENT_BY_REF(fptr, 2)) {
+		} else if (QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 1) || QUICK_ARG_SHOULD_BE_SENT_BY_REF(fptr, 2)) {
 			zend_error(error_type, "Method %s::__callStatic() cannot take arguments by reference", ZSTR_VAL(ce->name));
 		}
  	} else if (name_len == sizeof(ZEND_TOSTRING_FUNC_NAME) - 1 &&

--- a/ext/dba/dba.c
+++ b/ext/dba/dba.c
@@ -889,7 +889,7 @@ restart:
 			spprintf(&lock_name, 0, "%s.lck", info->path);
 			if (!strcmp(file_mode, "r")) {
 				/* when in read only mode try to use existing .lck file first */
-				/* do not log errors for .lck file while in read ony mode on .lck file */
+				/* do not log errors for .lck file while in read only mode on .lck file */
 				lock_file_mode = "rb";
 				info->lock.fp = php_stream_open_wrapper(lock_name, lock_file_mode, STREAM_MUST_SEEK|IGNORE_PATH|persistent_flag, &opened_path);
 			}

--- a/ext/dba/dba_cdb.c
+++ b/ext/dba/dba_cdb.c
@@ -183,7 +183,7 @@ DBA_UPDATE_FUNC(cdb)
 	if (!cdb->make)
 		return FAILURE; /* database was opened readonly */
 	if (!mode)
-		return FAILURE; /* cdb_make dosn't know replace */
+		return FAILURE; /* cdb_make doesn't know replace */
 	if (cdb_make_add(&cdb->m, key, keylen, val, vallen) != -1)
 		return SUCCESS;
 #endif

--- a/ext/dom/node.c
+++ b/ext/dom/node.c
@@ -291,7 +291,7 @@ int dom_node_node_value_read(dom_object *obj, zval *retval)
 		return FAILURE;
 	}
 
-	/* Access to Element node is implemented as a convience method */
+	/* Access to Element node is implemented as a convenience method */
 	switch (nodep->type) {
 		case XML_ATTRIBUTE_NODE:
 		case XML_TEXT_NODE:
@@ -329,7 +329,7 @@ int dom_node_node_value_write(dom_object *obj, zval *newval)
 		return FAILURE;
 	}
 
-	/* Access to Element node is implemented as a convience method */
+	/* Access to Element node is implemented as a convenience method */
 	switch (nodep->type) {
 		case XML_ELEMENT_NODE:
 		case XML_ATTRIBUTE_NODE:

--- a/ext/exif/exif.c
+++ b/ext/exif/exif.c
@@ -2969,7 +2969,7 @@ static int exif_process_string_raw(char **result, char *value, size_t byte_count
  * In contrast to exif_process_string this function does always return a string buffer */
 static int exif_process_string(char **result, char *value, size_t byte_count) {
 	/* we cannot use strlcpy - here the problem is that we cannot use strlen to
-	 * determin length of string and we cannot use strlcpy with len=byte_count+1
+	 * determine length of string and we cannot use strlcpy with len=byte_count+1
 	 * because then we might get into an EXCEPTION if we exceed an allocated
 	 * memory page...so we use php_strnlen in conjunction with memcpy and add the NUL
 	 * char.
@@ -3651,7 +3651,7 @@ static void exif_process_TIFF_in_JPEG(image_info_type *ImageInfo, char *CharBuf,
 	exif_error_docref(NULL EXIFERR_CC, ImageInfo, E_NOTICE, "Process TIFF in JPEG done");
 #endif
 
-	/* Compute the CCD width, in milimeters. */
+	/* Compute the CCD width, in millimeters. */
 	if (ImageInfo->FocalplaneXRes != 0) {
 		ImageInfo->CCDWidth = (float)(ImageInfo->ExifImageWidth * ImageInfo->FocalplaneUnits / ImageInfo->FocalplaneXRes);
 	}
@@ -3716,7 +3716,7 @@ static int exif_scan_JPEG_header(image_info_type *ImageInfo)
 
 		/* get marker byte, swallowing possible padding                           */
 		/* some software does not count the length bytes of COM section           */
-		/* one company doing so is very much envolved in JPEG... so we accept too */
+		/* one company doing so is very much involved in JPEG... so we accept too */
 		if (last_marker==M_COM && comment_correction) {
 			comment_correction = 2;
 		}

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -806,13 +806,13 @@ static void *zend_ffi_create_callback(zend_ffi_type *type, zval *value) /* {{{ *
 	}
 
 	if (!zend_is_callable_ex(value, NULL, 0, NULL, &fcc, &error)) {
-		zend_throw_error(zend_ffi_exception_ce, "Attempt to assing an invalid callback, %s", error);
+		zend_throw_error(zend_ffi_exception_ce, "Attempt to assign an invalid callback, %s", error);
 		return NULL;
 	}
 
 	arg_count = type->func.args ? zend_hash_num_elements(type->func.args) : 0;
 	if (arg_count < fcc.function_handler->common.required_num_args) {
-		zend_throw_error(zend_ffi_exception_ce, "Attempt to assing an invalid callback, insufficient number of arguments");
+		zend_throw_error(zend_ffi_exception_ce, "Attempt to assign an invalid callback, insufficient number of arguments");
 		return NULL;
 	}
 

--- a/ext/ffi/ffi.c
+++ b/ext/ffi/ffi.c
@@ -1776,13 +1776,11 @@ static int zend_ffi_cdata_get_closure(zval *obj, zend_class_entry **ce_ptr, zend
 	func->common.arg_flags[2] = 0;
 	func->common.fn_flags = ZEND_ACC_CALL_VIA_TRAMPOLINE;
 	func->common.function_name = ZSTR_KNOWN(ZEND_STR_MAGIC_INVOKE);
-	func->common.num_args = func->common.required_num_args = type->func.args ? zend_hash_num_elements(type->func.args) : 0;
+	/* set to 0 to avoid arg_info[] allocation, because all values are passed by value anyway */
+	func->common.num_args = 0;
+	func->common.required_num_args = type->func.args ? zend_hash_num_elements(type->func.args) : 0;
+	func->common.arg_info = NULL;
 	func->internal_function.handler = ZEND_FN(ffi_trampoline);
-
-	if (func->common.num_args > MAX_ARG_FLAG_NUM) {
-		func->common.arg_info = emalloc(sizeof(zend_arg_info) * func->common.num_args);
-		memset(func->common.arg_info, 0, sizeof(zend_arg_info) * func->common.num_args);
-	}
 
 	func->internal_function.reserved[0] = type;
 	func->internal_function.reserved[1] = *(void**)cdata->ptr;
@@ -2447,9 +2445,6 @@ static ZEND_FUNCTION(ffi_trampoline) /* {{{ */
 
 	zend_string_release(EX(func)->common.function_name);
 	if (EX(func)->common.fn_flags & ZEND_ACC_CALL_VIA_TRAMPOLINE) {
-		if (EX(func)->common.arg_info) {
-			efree(EX(func)->common.arg_info);
-		}
 		zend_free_trampoline(EX(func));
 		EX(func) = NULL;
 	}
@@ -2507,13 +2502,11 @@ static zend_function *zend_ffi_get_func(zend_object **obj, zend_string *name, co
 	func->common.arg_flags[2] = 0;
 	func->common.fn_flags = ZEND_ACC_CALL_VIA_TRAMPOLINE;
 	func->common.function_name = zend_string_copy(name);
-	func->common.num_args = func->common.required_num_args = type->func.args ? zend_hash_num_elements(type->func.args) : 0;
+	/* set to 0 to avoid arg_info[] allocation, because all values are passed by value anyway */
+	func->common.num_args = 0;
+	func->common.required_num_args = type->func.args ? zend_hash_num_elements(type->func.args) : 0;
+	func->common.arg_info = NULL;
 	func->internal_function.handler = ZEND_FN(ffi_trampoline);
-
-	if (func->common.num_args > MAX_ARG_FLAG_NUM) {
-		func->common.arg_info = emalloc(sizeof(zend_arg_info) * func->common.num_args);
-		memset(func->common.arg_info, 0, sizeof(zend_arg_info) * func->common.num_args);
-	}
 
 	func->internal_function.reserved[0] = type;
 	func->internal_function.reserved[1] = sym->addr;

--- a/ext/ffi/tests/bug77632.phpt
+++ b/ext/ffi/tests/bug77632.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Bug #77632 (FFI Segfaults When Called With Variadics)
+--SKIPIF--
+<?php require_once('skipif.inc'); ?>
+--INI--
+ffi.enable=1
+--FILE--
+<?php
+$libc = FFI::cdef("int printf(const char *format, ...);", "libc.so.6");
+$args = ["test\n"];
+$libc->printf(...$args);
+?>
+--EXPECT--
+test

--- a/ext/reflection/php_reflection.c
+++ b/ext/reflection/php_reflection.c
@@ -3113,7 +3113,7 @@ static void reflection_method_invoke(INTERNAL_FUNCTION_PARAMETERS, int variadic)
 		} ZEND_HASH_FOREACH_END();
 	}
 
-	/* In case this is a static method, we should'nt pass an object_ptr
+	/* In case this is a static method, we shouldn't pass an object_ptr
 	 * (which is used as calling context aka $this). We can thus ignore the
 	 * first parameter.
 	 *

--- a/ext/standard/basic_functions.c
+++ b/ext/standard/basic_functions.c
@@ -4905,7 +4905,7 @@ PHP_FUNCTION(error_clear_last)
 }
 /* }}} */
 
-/* {{{ proto mixed call_user_func(mixed function_name [, mixed parmeter] [, mixed ...])
+/* {{{ proto mixed call_user_func(mixed function_name [, mixed parameter] [, mixed ...])
    Call a user function which is the first parameter
    Warning: This function is special-cased by zend_compile.c and so is usually bypassed */
 PHP_FUNCTION(call_user_func)
@@ -4958,7 +4958,7 @@ PHP_FUNCTION(call_user_func_array)
 }
 /* }}} */
 
-/* {{{ proto mixed forward_static_call(mixed function_name [, mixed parmeter] [, mixed ...]) U
+/* {{{ proto mixed forward_static_call(mixed function_name [, mixed parameter] [, mixed ...]) U
    Call a user function which is the first parameter */
 PHP_FUNCTION(forward_static_call)
 {

--- a/ext/standard/ftp_fopen_wrapper.c
+++ b/ext/standard/ftp_fopen_wrapper.c
@@ -1061,7 +1061,7 @@ static int php_stream_ftp_mkdir(php_stream_wrapper *wrapper, const char *url, in
 		php_stream_printf(stream, "MKD %s\r\n", ZSTR_VAL(resource->path));
 		result = GET_FTP_RESULT(stream);
     } else {
-        /* we look for directory separator from the end of string, thus hopefuly reducing our work load */
+        /* we look for directory separator from the end of string, thus hopefully reducing our work load */
         char *p, *e, *buf;
 
         buf = estrndup(ZSTR_VAL(resource->path), ZSTR_LEN(resource->path));

--- a/ext/standard/image.c
+++ b/ext/standard/image.c
@@ -613,7 +613,7 @@ static struct gfxinfo *php_handle_jpc(php_stream * stream)
 	   "bit depth" answer somewhat problematic. For this implementation
 	   we'll use the highest depth encountered. */
 
-	/* Get the single byte that remains after the file type indentification */
+	/* Get the single byte that remains after the file type identification */
 	first_marker_id = php_stream_getc(stream);
 
 	/* Ensure that this marker is SIZ (as is mandated by the standard) */

--- a/ext/standard/string.c
+++ b/ext/standard/string.c
@@ -1766,7 +1766,7 @@ PHP_FUNCTION(pathinfo)
 /* }}} */
 
 /* {{{ php_stristr
-   case insensitve strstr */
+   case insensitive strstr */
 PHPAPI char *php_stristr(char *s, char *t, size_t s_len, size_t t_len)
 {
 	php_strtolower(s, s_len);

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -329,6 +329,9 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_diagnose, 0, 0, 1)
     ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_INFO(arginfo_tidy_no_args, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_release, 0)
 ZEND_END_ARG_INFO()
 
@@ -444,40 +447,40 @@ static const zend_function_entry tidy_functions[] = {
 
 static const zend_function_entry tidy_funcs_doc[] = {
 	TIDY_METHOD_MAP(getOpt, tidy_getopt, arginfo_tidy_getopt_method)
-	TIDY_METHOD_MAP(cleanRepair, tidy_clean_repair, NULL)
+	TIDY_METHOD_MAP(cleanRepair, tidy_clean_repair, arginfo_tidy_no_args)
 	TIDY_DOC_ME(parseFile, arginfo_tidy_parse_file)
 	TIDY_DOC_ME(parseString, arginfo_tidy_parse_string)
 	TIDY_METHOD_MAP(repairString, tidy_repair_string, arginfo_tidy_repair_string)
 	TIDY_METHOD_MAP(repairFile, tidy_repair_file, arginfo_tidy_repair_file)
-	TIDY_METHOD_MAP(diagnose, tidy_diagnose, NULL)
-	TIDY_METHOD_MAP(getRelease, tidy_get_release, NULL)
-	TIDY_METHOD_MAP(getConfig, tidy_get_config, NULL)
-	TIDY_METHOD_MAP(getStatus, tidy_get_status, NULL)
-	TIDY_METHOD_MAP(getHtmlVer, tidy_get_html_ver, NULL)
+	TIDY_METHOD_MAP(diagnose, tidy_diagnose, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getRelease, tidy_get_release, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getConfig, tidy_get_config, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getStatus, tidy_get_status, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(getHtmlVer, tidy_get_html_ver, arginfo_tidy_no_args)
 #if HAVE_TIDYOPTGETDOC
 	TIDY_METHOD_MAP(getOptDoc, tidy_get_opt_doc, arginfo_tidy_get_opt_doc_method)
 #endif
-	TIDY_METHOD_MAP(isXhtml, tidy_is_xhtml, NULL)
-	TIDY_METHOD_MAP(isXml, tidy_is_xml, NULL)
-	TIDY_METHOD_MAP(root, tidy_get_root, NULL)
-	TIDY_METHOD_MAP(head, tidy_get_head, NULL)
-	TIDY_METHOD_MAP(html, tidy_get_html, NULL)
-	TIDY_METHOD_MAP(body, tidy_get_body, NULL)
+	TIDY_METHOD_MAP(isXhtml, tidy_is_xhtml, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(isXml, tidy_is_xml, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(root, tidy_get_root, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(head, tidy_get_head, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(html, tidy_get_html, arginfo_tidy_no_args)
+	TIDY_METHOD_MAP(body, tidy_get_body, arginfo_tidy_no_args)
 	TIDY_DOC_ME(__construct, arginfo_tidy_construct)
 	PHP_FE_END
 };
 
 static const zend_function_entry tidy_funcs_node[] = {
-	TIDY_NODE_ME(hasChildren, NULL)
-	TIDY_NODE_ME(hasSiblings, NULL)
-	TIDY_NODE_ME(isComment, NULL)
-	TIDY_NODE_ME(isHtml, NULL)
-	TIDY_NODE_ME(isText, NULL)
-	TIDY_NODE_ME(isJste, NULL)
-	TIDY_NODE_ME(isAsp, NULL)
-	TIDY_NODE_ME(isPhp, NULL)
-	TIDY_NODE_ME(getParent, NULL)
-	TIDY_NODE_PRIVATE_ME(__construct, NULL)
+	TIDY_NODE_ME(hasChildren, arginfo_tidy_no_args)
+	TIDY_NODE_ME(hasSiblings, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isComment, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isHtml, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isText, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isJste, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isAsp, arginfo_tidy_no_args)
+	TIDY_NODE_ME(isPhp, arginfo_tidy_no_args)
+	TIDY_NODE_ME(getParent, arginfo_tidy_no_args)
+	TIDY_NODE_PRIVATE_ME(__construct, arginfo_tidy_no_args)
 	PHP_FE_END
 };
 

--- a/ext/tidy/tidy.c
+++ b/ext/tidy/tidy.c
@@ -379,17 +379,25 @@ ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_config_count, 0, 0, 1)
     ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_getopt, 0, 0, 1)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_getopt_method, 0, 0, 1)
 	ZEND_ARG_INFO(0, option)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_root, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_getopt, 0, 0, 2)
+	ZEND_ARG_INFO(0, object)
+	ZEND_ARG_INFO(0, option)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_html, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_get_root, 0, 0, 1)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_INFO(arginfo_tidy_get_head, 0)
+ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_get_html, 0, 0, 1)
+	ZEND_ARG_INFO(0, object)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_get_head, 0, 0, 1)
+	ZEND_ARG_INFO(0, object)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_INFO_EX(arginfo_tidy_get_body, 0, 0, 1)
@@ -435,7 +443,7 @@ static const zend_function_entry tidy_functions[] = {
 };
 
 static const zend_function_entry tidy_funcs_doc[] = {
-	TIDY_METHOD_MAP(getOpt, tidy_getopt, arginfo_tidy_getopt)
+	TIDY_METHOD_MAP(getOpt, tidy_getopt, arginfo_tidy_getopt_method)
 	TIDY_METHOD_MAP(cleanRepair, tidy_clean_repair, NULL)
 	TIDY_DOC_ME(parseFile, arginfo_tidy_parse_file)
 	TIDY_DOC_ME(parseString, arginfo_tidy_parse_string)


### PR DESCRIPTION
This prevents subclasses from being written with incompatible
implementations, e.g. expecting more required args.