### PR TITLE
[WIP][POC] Serialize undefined declared values as undefined

### DIFF
--- a/ext/standard/tests/serialize/serialize_as_undef.phpt
+++ b/ext/standard/tests/serialize/serialize_as_undef.phpt
@@ -1,0 +1,24 @@
+--TEST--
+serialize() serializing array values as undefined
+--FILE--
+<?php
+class NoSleep {
+    public int $x;
+}
+$x = new NoSleep();
+// TODO: Only do this for serialize($x, ['explicit_undefined' => true])
+echo ($s = serialize($x)), "\n";
+$sCopy = unserialize($s);
+var_export($sCopy);
+echo "\n";
+try {
+    $sCopy->x = 'invalid';
+} catch (TypeError $e) {
+    echo $e->getMessage(), "\n";
+}
+?>
+--EXPECT--
+O:7:"NoSleep":1:{s:1:"x";U;}
+NoSleep::__set_state(array(
+))
+Cannot assign string to property NoSleep::$x of type int


### PR DESCRIPTION
**This is extremely incomplete, and the bare minimum to serialize and
unserialize a single object property.**
A real implementation would:

- Require an option such as 'explicit_undefined' => true when unserializing
- Reject arrays, standalone U;, etc.
- Support __serialize() and __sleep()
- Handle internal classes using undefined properties in serialize()
- Add tests that internal classes such as DateTime handle invalid data properly.
- Have more tests of edge cases
- Fix issues identified by the fuzzer