### PR TITLE
Autovivication prototype and investigation notes

### DIFF
--- a/Zend/zend_object_handlers.c
+++ b/Zend/zend_object_handlers.c
@@ -982,6 +982,7 @@ ZEND_API zval *zend_std_get_property_ptr_ptr(zend_object *zobj, zend_string *nam
 				rebuild_object_properties(zobj);
 			}
 			retval = zend_hash_update(zobj->properties, name, &EG(uninitialized_zval));
+			// NOTE: retval will have type IS_NULL
 			/* Notice is thrown after creation of the property, to avoid EG(std_property_info)
 			 * being overwritten in an error handler. */
 			if (UNEXPECTED(type == BP_VAR_RW || type == BP_VAR_R)) {

--- a/Zend/zend_vm_def.h
+++ b/Zend/zend_vm_def.h
@@ -2601,6 +2601,15 @@ ZEND_VM_C_LABEL(try_assign_dim_array):
 				FREE_OP_DATA();
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if OP1_TYPE == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					ZEND_VM_C_GOTO(assign_dim_error);
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {

--- a/Zend/zend_vm_execute.h
+++ b/Zend/zend_vm_execute.h
@@ -23396,6 +23396,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -23509,6 +23518,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -23622,6 +23640,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -23734,6 +23761,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -25974,6 +26010,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -26087,6 +26132,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -26200,6 +26254,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -26312,6 +26375,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -27341,6 +27413,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -27454,6 +27535,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -27567,6 +27657,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -27679,6 +27778,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -29900,6 +30008,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -30013,6 +30130,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -30126,6 +30252,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -30238,6 +30373,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_VAR == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -40895,6 +41039,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -41008,6 +41161,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -41121,6 +41283,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -41233,6 +41404,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -44544,6 +44724,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -44657,6 +44846,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -44770,6 +44968,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -44882,6 +45089,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -46357,6 +46573,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -46470,6 +46695,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -46583,6 +46817,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -46695,6 +46938,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -49575,6 +49827,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -49688,6 +49949,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -49801,6 +50071,15 @@ try_assign_dim_array:
 				zval_ptr_dtor_nogc(EX_VAR((opline+1)->op1.var));
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {
@@ -49913,6 +50192,15 @@ try_assign_dim_array:
 
 			}
 		} else if (EXPECTED(Z_TYPE_P(object_ptr) <= IS_FALSE)) {
+#if IS_CV == IS_CV
+			if (Z_TYPE_P(object_ptr) >= IS_NULL) {
+				zend_error(E_DEPRECATED,
+					"Automatic conversion of %s to array on field assignment is deprecated", Z_TYPE_P(object_ptr) == IS_NULL ? "null" : "false");
+				if (UNEXPECTED(EG(exception))) {
+					goto assign_dim_error;
+				}
+			}
+#endif
 			if (Z_ISREF_P(orig_object_ptr)
 			 && ZEND_REF_HAS_TYPE_SOURCES(Z_REF_P(orig_object_ptr))
 			 && !zend_verify_ref_array_assignable(Z_REF_P(orig_object_ptr))) {


### PR DESCRIPTION
**This is not the implementation for
https://wiki.php.net/rfc/autovivification_false - it is a quick and dirty
prototype to quickly check on the impact autovivication would have on production
applications. I am not involved in that RFC.**

1. `For $obj->dynamicProp[] = 123;`, they cannot currently be distinguished
   for undeclared properties because $obj->dynamicProp is converted to null when
   fetching the property for purposes of assignment.

   **As a workaround, this prototype ignores null on dynamic object properties
   to avoid false positives.** (I assume an actual implementation for null would do something more robust and complicated such as add a new bit flag to indicate the property was created)
2. Zend/optimizer would need to be updated to account for the opcodes that can
   now throw or have side effects such as emitting notices.

   This quick and dirty prototype does not implement that.
3. There may be more issues with references.
4. There may be more opcodes.
5. Exception handling and memory management was not tested
6. `$this->actuallyAnArray[$i0][$i1][$i2][$i3] = $var` is buggy

For php's tests of itself, null causes a lot more failures than false, e.g. https://github.com/php/php-src/blob/master/Zend/tests/gc_017.phpt

Static analyzers seem pretty effective, e.g. https://github.com/phan/phan had no issues when analyzing itself. Applications that don't use static analyzers or that don't have complete type information may encounter a lot more notices for null.